### PR TITLE
Add Burmese translations of "yes" and "no" for the Myanmar locale

### DIFF
--- a/public/christmas.js
+++ b/public/christmas.js
@@ -172,7 +172,7 @@ var Christmas = {
       "NI": "NO", // Nicaragua
       "PY": "NO", // Paraguay
       "VN": "SAI", // Vietnam
-      "MM": "မဟုတ္ဘူ။ူ။" // Myanmar (Burmese)
+      "MM": "မဟုတ္ဘူ။" // Myanmar (Burmese)
     }
 
     return codes[countryCode] || "NO";


### PR DESCRIPTION
I've lifted Burmese translations of "yes" and "no" from http://wikitravel.org/en/Burmese_phrasebook, which match fairly closely with http://www.ornagai.com/ and http://www.burmese-dictionary.org/.
