### PR TITLE
Adds shortcuts to dev console

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -136,7 +136,7 @@
   <div id="links">
     <a href="https://twitter.com/konklone" target="_blank">by @konklone</a>
     <a href="https://ifttt.com/isitchristmas" target="_blank">on IFTTT</a>
-    <a href="https://developer.chrome.com/devtools/docs/console" target="_blank">Command - Option - J (Mac) or Control - Shift - J (Windows/Linux)</a>
+    <a href="https://developer.chrome.com/devtools/docs/console" target="_blank">You'll want to open the console: Command - Option - J (Mac) or Control - Shift - J (Windows/Linux)</a>
   </div>
 
   <div id="legend"></div>


### PR DESCRIPTION
- Adds correct shortcuts for Mac and Windows/Linux to info at top of site
- Link goes to info page on developer console from Chrome

NB: This is untested as I didn't know how to run node etc, but it just adds another anchor tag along the lines of what's already there -- v. low probability that it is breaking anything. However, testing would be good @konklone :)
